### PR TITLE
나의 프로필 서비스 기능 추가

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,4 +16,5 @@ java -jar ./app.jar \
   --app.auth.tokenExpiration="$EXPIRATION_TIME" \
   --app.auth.refreshTokenExpiration="$REFRESH_EXPIRATION_TIME" \
   --app.cors.allowedOrigins="$FRONT_URL" \
-  --app.oauth2.authorizedRedirectUris="$FRONT_URL"
+  --app.oauth2.authorizedRedirectUris="$FRONT_URL" \
+  --app.kakaoAccount.serviceAppAdminKey = "$SERVICE_APP_ADMIN_KEY"

--- a/src/main/java/com/triprint/backend/core/config/AppProperties.java
+++ b/src/main/java/com/triprint/backend/core/config/AppProperties.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 public class AppProperties {
 	private final Auth auth = new Auth();
 	private final OAuth2 oauth2 = new OAuth2();
-	private final KakaoAccount leave = new KakaoAccount();
+	private final KakaoAccount kakaoAccount = new KakaoAccount();
 
 	@Getter
 	@Setter

--- a/src/main/java/com/triprint/backend/core/config/AppProperties.java
+++ b/src/main/java/com/triprint/backend/core/config/AppProperties.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 public class AppProperties {
 	private final Auth auth = new Auth();
 	private final OAuth2 oauth2 = new OAuth2();
+	private final KakaoAccount leave = new KakaoAccount();
 
 	@Getter
 	@Setter
@@ -40,5 +41,13 @@ public class AppProperties {
 			this.authorizedRedirectUris = authorizedRedirectUris;
 			return this;
 		}
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class KakaoAccount {
+		private String serviceAppAdminKey;
 	}
 }

--- a/src/main/java/com/triprint/backend/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/triprint/backend/domain/follow/controller/FollowController.java
@@ -50,28 +50,28 @@ public class FollowController {
 
 	@GetMapping("/follower")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	ResponseEntity<Page<UserInfoResponse>> getFollowers(@CurrentUser UserPrincipal userPrincipal,
+	ResponseEntity<Page<UserInfoResponse>> getMyFollowers(@CurrentUser UserPrincipal userPrincipal,
 		@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 		return ResponseEntity.ok(followService.getMyFollowers(userPrincipal.getId(), pageable));
 	}
 
 	@GetMapping("/following")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	ResponseEntity<Page<UserInfoResponse>> getFollowings(@CurrentUser UserPrincipal userPrincipal,
+	ResponseEntity<Page<UserInfoResponse>> getMyFollowings(@CurrentUser UserPrincipal userPrincipal,
 		@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 		return ResponseEntity.ok(followService.getMyFollowings(userPrincipal.getId(), pageable));
 	}
 
 	@GetMapping("/follower/{id}")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	ResponseEntity<Page<GetFollowResponse>> getOtherFollowers(@CurrentUser UserPrincipal userPrincipal,
+	ResponseEntity<Page<GetFollowResponse>> getFollowers(@CurrentUser UserPrincipal userPrincipal,
 		@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @PathVariable Long id) {
 		return ResponseEntity.ok(followService.getFollowers(userPrincipal.getId(), id, pageable));
 	}
 
 	@GetMapping("/following/{id}")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	ResponseEntity<Page<GetFollowResponse>> getOtherFollowings(@CurrentUser UserPrincipal userPrincipal,
+	ResponseEntity<Page<GetFollowResponse>> getFollowings(@CurrentUser UserPrincipal userPrincipal,
 		@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @PathVariable Long id) {
 		return ResponseEntity.ok(followService.getFollowings(userPrincipal.getId(), id, pageable));
 	}

--- a/src/main/java/com/triprint/backend/domain/trip/controller/TripController.java
+++ b/src/main/java/com/triprint/backend/domain/trip/controller/TripController.java
@@ -54,9 +54,8 @@ public class TripController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<GetTripResponse> getTrip(@CurrentUser UserPrincipal userPrincipal,
-		@PathVariable Long id) {
-		return new ResponseEntity<>(tripService.getTrip(id, userPrincipal), HttpStatus.OK);
+	public ResponseEntity<GetTripResponse> getTrip(@PathVariable Long id) {
+		return new ResponseEntity<>(tripService.getTrip(id), HttpStatus.OK);
 	}
 
 	@PutMapping("/{id}")

--- a/src/main/java/com/triprint/backend/domain/trip/service/TripService.java
+++ b/src/main/java/com/triprint/backend/domain/trip/service/TripService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.triprint.backend.core.exception.ErrorMessage;
 import com.triprint.backend.core.exception.ForbiddenException;
 import com.triprint.backend.core.exception.ResourceNotFoundException;
-import com.triprint.backend.domain.auth.security.UserPrincipal;
 import com.triprint.backend.domain.post.entity.Post;
 import com.triprint.backend.domain.post.repository.PostRepository;
 import com.triprint.backend.domain.trip.dto.CreateOrUpdateTripRequest;
@@ -51,7 +50,7 @@ public class TripService {
 	}
 
 	@Transactional
-	public GetTripResponse getTrip(Long id, UserPrincipal userPrincipal) {
+	public GetTripResponse getTrip(Long id) {
 		Trip trip = tripRepository.findById(id).orElseThrow(() -> {
 			throw new ResourceNotFoundException(ErrorMessage.TRIP_NOT_FOUND);
 		});

--- a/src/main/java/com/triprint/backend/domain/user/controller/MyProfileController.java
+++ b/src/main/java/com/triprint/backend/domain/user/controller/MyProfileController.java
@@ -1,9 +1,8 @@
 package com.triprint.backend.domain.user.controller;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +17,7 @@ import com.triprint.backend.domain.user.dto.MyProfileImgResponse;
 import com.triprint.backend.domain.user.dto.MyProfileRequest;
 import com.triprint.backend.domain.user.dto.MyProfileResponse;
 import com.triprint.backend.domain.user.service.MyProfileService;
+import com.triprint.backend.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class MyProfileController {
 
 	private final MyProfileService myProfileService;
+	private final UserService userService;
 
 	@GetMapping("/profile")
 	@PreAuthorize("hasRole('ROLE_USER')")
@@ -36,19 +37,26 @@ public class MyProfileController {
 
 	@PutMapping("/profile")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	ResponseEntity<MyProfileResponse> updateMyProfile(HttpServletRequest request,
+	ResponseEntity<MyProfileResponse> updateMyProfile(@CurrentUser UserPrincipal userPrincipal,
 		@RequestBody MyProfileRequest myProfileRequest) {
 		return ResponseEntity.ok(
-			myProfileService.updateMyProfile((Long)request.getAttribute("userId"), myProfileRequest.getUsername()));
+			myProfileService.updateMyProfile(userPrincipal.getId(), myProfileRequest.getUsername()));
 	}
 
 	@PutMapping("/profile-img")
 	@PreAuthorize("hasRole('ROLE_USER')")
 	ResponseEntity<MyProfileImgResponse> updateMyProfileImg(
-		HttpServletRequest request,
+		@CurrentUser UserPrincipal userPrincipal,
 		@RequestPart(value = "file") MultipartFile multipartFile
 	) {
 		return ResponseEntity.ok(
-			myProfileService.updateMyProfileImg((Long)request.getAttribute("userId"), multipartFile));
+			myProfileService.updateMyProfileImg(userPrincipal.getId(), multipartFile));
+	}
+
+	@DeleteMapping("/quit")
+	@PreAuthorize("hasRole('ROLE_USER')")
+	ResponseEntity<Object> quit(@CurrentUser UserPrincipal userPrincipal) throws Exception {
+		userService.quit(userPrincipal.getId());
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
+++ b/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
@@ -19,4 +19,6 @@ public class MyProfileResponse {
 	private String username;
 	private String profileImg;
 	private Page<GetMyTripResponse> myTrips;
+	private Page<UserInfoResponse> myFollowers;
+	private Page<UserInfoResponse> myFollowings;
 }

--- a/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
+++ b/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
@@ -1,5 +1,9 @@
 package com.triprint.backend.domain.user.dto;
 
+import org.springframework.data.domain.Page;
+
+import com.triprint.backend.domain.trip.dto.GetMyTripResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +18,5 @@ public class MyProfileResponse {
 	private String email;
 	private String username;
 	private String profileImg;
+	private Page<GetMyTripResponse> myTrips;
 }

--- a/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
+++ b/src/main/java/com/triprint/backend/domain/user/dto/MyProfileResponse.java
@@ -1,24 +1,20 @@
 package com.triprint.backend.domain.user.dto;
 
-import org.springframework.data.domain.Page;
+import com.triprint.backend.domain.user.entity.User;
 
-import com.triprint.backend.domain.trip.dto.GetMyTripResponse;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class MyProfileResponse {
-	private Long id;
-	private String email;
-	private String username;
-	private String profileImg;
-	private Page<GetMyTripResponse> myTrips;
-	private Page<UserInfoResponse> myFollowers;
-	private Page<UserInfoResponse> myFollowings;
+public class MyProfileResponse extends UserInfoResponse {
+
+	private int myTrips;
+	private int myFollowers;
+	private int myFollowings;
+
+	public MyProfileResponse(User user) {
+		super(user);
+		myTrips = user.getTrip().size();
+		myFollowers = user.getFollowers().size();
+		myFollowings = user.getFollowings().size();
+	}
 }

--- a/src/main/java/com/triprint/backend/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/triprint/backend/domain/user/dto/UserInfoResponse.java
@@ -7,12 +7,14 @@ import lombok.Getter;
 @Getter
 public class UserInfoResponse {
 	private Long id;
+	private String email;
 	private String username;
 	private String profileImg;
 
 	public UserInfoResponse(User author) {
-		this.id = author.getId();
-		this.username = author.getUsername();
-		this.profileImg = author.getProfileImg();
+		id = author.getId();
+		email = author.getEmail();
+		username = author.getUsername();
+		profileImg = author.getProfileImg();
 	}
 }

--- a/src/main/java/com/triprint/backend/domain/user/entity/User.java
+++ b/src/main/java/com/triprint/backend/domain/user/entity/User.java
@@ -14,6 +14,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -38,6 +39,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@SQLDelete(sql = "UPDATE user SET deleted = true WHERE id = ?")
 public class User {
 	@Id
 	@GeneratedValue(
@@ -50,6 +52,8 @@ public class User {
 	private String password;
 
 	private String email;
+	
+	private boolean deleted = Boolean.FALSE;
 
 	@Enumerated(EnumType.STRING)
 	private UserRole role;

--- a/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
+++ b/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
@@ -8,10 +8,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.triprint.backend.core.exception.ErrorMessage;
 import com.triprint.backend.core.exception.ResourceNotFoundException;
+import com.triprint.backend.domain.follow.service.FollowService;
 import com.triprint.backend.domain.trip.dto.GetMyTripResponse;
 import com.triprint.backend.domain.trip.service.TripService;
 import com.triprint.backend.domain.user.dto.MyProfileImgResponse;
 import com.triprint.backend.domain.user.dto.MyProfileResponse;
+import com.triprint.backend.domain.user.dto.UserInfoResponse;
 import com.triprint.backend.domain.user.entity.User;
 import com.triprint.backend.domain.user.repository.UserRepository;
 
@@ -24,6 +26,7 @@ public class MyProfileService {
 	private final UserRepository userRepository;
 	private final AwsS3Service awsS3Service;
 	private final TripService tripService;
+	private final FollowService followService;
 
 	public MyProfileResponse getMyProfile(Long userId) {
 
@@ -32,6 +35,8 @@ public class MyProfileService {
 		});
 
 		Page<GetMyTripResponse> trips = tripService.getMyTripList(userId, Pageable.unpaged());
+		Page<UserInfoResponse> myFollowers = followService.getMyFollowers(userId, Pageable.unpaged());
+		Page<UserInfoResponse> myFollowings = followService.getMyFollowings(userId, Pageable.unpaged());
 
 		return MyProfileResponse.builder()
 			.id(userId)
@@ -39,6 +44,8 @@ public class MyProfileService {
 			.username(user.getUsername())
 			.profileImg(user.getProfileImg())
 			.myTrips(trips)
+			.myFollowers(myFollowers)
+			.myFollowings(myFollowings)
 			.build();
 	}
 

--- a/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
+++ b/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
@@ -1,7 +1,5 @@
 package com.triprint.backend.domain.user.service;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,11 +7,9 @@ import org.springframework.web.multipart.MultipartFile;
 import com.triprint.backend.core.exception.ErrorMessage;
 import com.triprint.backend.core.exception.ResourceNotFoundException;
 import com.triprint.backend.domain.follow.service.FollowService;
-import com.triprint.backend.domain.trip.dto.GetMyTripResponse;
 import com.triprint.backend.domain.trip.service.TripService;
 import com.triprint.backend.domain.user.dto.MyProfileImgResponse;
 import com.triprint.backend.domain.user.dto.MyProfileResponse;
-import com.triprint.backend.domain.user.dto.UserInfoResponse;
 import com.triprint.backend.domain.user.entity.User;
 import com.triprint.backend.domain.user.repository.UserRepository;
 
@@ -34,19 +30,7 @@ public class MyProfileService {
 			throw new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND);
 		});
 
-		Page<GetMyTripResponse> trips = tripService.getMyTripList(userId, Pageable.unpaged());
-		Page<UserInfoResponse> myFollowers = followService.getMyFollowers(userId, Pageable.unpaged());
-		Page<UserInfoResponse> myFollowings = followService.getMyFollowings(userId, Pageable.unpaged());
-
-		return MyProfileResponse.builder()
-			.id(userId)
-			.email(user.getEmail())
-			.username(user.getUsername())
-			.profileImg(user.getProfileImg())
-			.myTrips(trips)
-			.myFollowers(myFollowers)
-			.myFollowings(myFollowings)
-			.build();
+		return new MyProfileResponse(user);
 	}
 
 	public MyProfileResponse updateMyProfile(Long userId, String username) {
@@ -60,12 +44,7 @@ public class MyProfileService {
 			throw new RuntimeException("중복되는 닉네임을 입력하셨습니다.");
 		}
 
-		return MyProfileResponse.builder()
-			.id(userId)
-			.email(user.getEmail())
-			.username(user.getUsername())
-			.profileImg(user.getProfileImg())
-			.build();
+		return new MyProfileResponse(user);
 	}
 
 	@Transactional

--- a/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
+++ b/src/main/java/com/triprint/backend/domain/user/service/MyProfileService.java
@@ -1,11 +1,15 @@
 package com.triprint.backend.domain.user.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.triprint.backend.core.exception.ErrorMessage;
 import com.triprint.backend.core.exception.ResourceNotFoundException;
+import com.triprint.backend.domain.trip.dto.GetMyTripResponse;
+import com.triprint.backend.domain.trip.service.TripService;
 import com.triprint.backend.domain.user.dto.MyProfileImgResponse;
 import com.triprint.backend.domain.user.dto.MyProfileResponse;
 import com.triprint.backend.domain.user.entity.User;
@@ -19,18 +23,22 @@ public class MyProfileService {
 
 	private final UserRepository userRepository;
 	private final AwsS3Service awsS3Service;
+	private final TripService tripService;
 
-	public MyProfileResponse getMyProfile(Long memberId) {
+	public MyProfileResponse getMyProfile(Long userId) {
 
-		User user = userRepository.findById(memberId).orElseThrow(() -> {
+		User user = userRepository.findById(userId).orElseThrow(() -> {
 			throw new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND);
 		});
 
+		Page<GetMyTripResponse> trips = tripService.getMyTripList(userId, Pageable.unpaged());
+
 		return MyProfileResponse.builder()
-			.id(memberId)
+			.id(userId)
 			.email(user.getEmail())
 			.username(user.getUsername())
 			.profileImg(user.getProfileImg())
+			.myTrips(trips)
 			.build();
 	}
 

--- a/src/main/java/com/triprint/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/triprint/backend/domain/user/service/UserService.java
@@ -1,7 +1,17 @@
 package com.triprint.backend.domain.user.service;
 
-import org.springframework.stereotype.Service;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.triprint.backend.core.config.AppProperties;
 import com.triprint.backend.core.exception.ErrorMessage;
 import com.triprint.backend.core.exception.ResourceNotFoundException;
 import com.triprint.backend.domain.user.entity.User;
@@ -14,9 +24,47 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final AppProperties appProperties;
 
 	public User findById(Long userid) {
 		return userRepository.findById(userid).orElseThrow(() ->
 			new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
 	}
+
+	@Transactional
+	public void quit(Long userId) throws Exception {
+		User user = userRepository.findById(userId).orElseThrow(() ->
+			new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+		requestUnlinkKakaoAccount(user.getProviderId());
+		userRepository.delete(user);
+	}
+
+	public void requestUnlinkKakaoAccount(String kakaoProviderId) throws Exception {
+		URI url = new URI("https://kapi.kakao.com/v1/user/unlink");
+		BodyPublisher body = BodyPublishers.ofString(
+			String.format("target_id_Type=user_id&target_id=%s", kakaoProviderId));
+		HttpRequest request = HttpRequest.newBuilder()
+			.uri(url)
+			.header("Content-Type", "application/x-www-url-encoded")
+			.header("Authorization",
+				String.format("KakaoAK %s", appProperties.getKakaoAccount().getServiceAppAdminKey()))
+			.POST(body)
+			.build();
+
+		HttpClient client = HttpClient.newBuilder().version(Version.HTTP_1_1).build();
+		/* 동기 `HttpResponse<String>` */
+		client.send(request, HttpResponse.BodyHandlers.ofString());
+
+		/* 비동기 = `CompletableFuture<HttpResponse<String>>` */
+		client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+	}
 }
+
+
+
+
+
+
+
+

--- a/src/main/java/com/triprint/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/triprint/backend/domain/user/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
 		client.send(request, HttpResponse.BodyHandlers.ofString());
 
 		/* 비동기 = `CompletableFuture<HttpResponse<String>>` */
-		client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+		// client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
 	}
 }
 


### PR DESCRIPTION
## 📝 세부사항
- 자바 11을 사용하고 있기에 HttpClient로  Http Request 기능을 활용함
- 카카오 로그인을 사용중이기에 해당 공식 문서를 보고 적용함
- MyProfile을 불러올 경우
- 사용자가 작성한 여행기도 같이 불러오는 기능을 구현함
- 사용자의 팔로워와 팔로잉을 같이 불러오는 기능을 구현함

## 📗 참고사항
- [카카오 연결끊기 과정](https://developers.kakao.com/docs/latest/ko/kakaologin/common#unlink-and-deregister)
- [HttpClient](https://lts0606.tistory.com/455)
- [Http요청에서 비동기로 진행할때 사용되는 CompletableFuture](https://mangkyu.tistory.com/263)
- [Soft Delete](https://velog.io/@max9106/JPA-soft-delete)

## 📎 관련 이슈

- Close #41
